### PR TITLE
Admin auth control

### DIFF
--- a/quickcomm/admin.py
+++ b/quickcomm/admin.py
@@ -3,6 +3,18 @@ from django.contrib import admin
 # Register your models here.
 
 from .models import Author, Post, Comment, Follow, Like
+from .models import RegistrationSettings
+from .forms import RegistrationSettingsForm
+
+# allow admin to make new accounts inactive
+
+
+class RegistrationSettingsAdmin(admin.ModelAdmin):
+    form = RegistrationSettingsForm
+
+
+admin.site.register(RegistrationSettings, RegistrationSettingsAdmin)
+
 
 admin.site.register(Author)
 admin.site.register(Post)

--- a/quickcomm/admin.py
+++ b/quickcomm/admin.py
@@ -2,22 +2,13 @@ from django.contrib import admin
 
 # Register your models here.
 
-from .models import Author, Post, Comment, Follow, Like
-from .models import RegistrationSettings
-from .forms import RegistrationSettingsForm
+from .models import Author, Post, Comment, Follow, Like, RegistrationSettings
 
 # allow admin to make new accounts inactive
-
-
-class RegistrationSettingsAdmin(admin.ModelAdmin):
-    form = RegistrationSettingsForm
-
-
-admin.site.register(RegistrationSettings, RegistrationSettingsAdmin)
-
 
 admin.site.register(Author)
 admin.site.register(Post)
 admin.site.register(Comment)
 admin.site.register(Follow)
 admin.site.register(Like)
+admin.site.register(RegistrationSettings)

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -62,9 +62,3 @@ class CreateMarkdownForm(forms.Form):
 class CreateLoginForm(forms.Form):
     display_name = forms.CharField(max_length=100)
     password = forms.CharField(widget=forms.PasswordInput())
-
-
-class CreateRegisterForm(forms.ModelForm):
-    class Meta:
-        model = User
-        fields = ['username', 'password']

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
-from .models import Post
+from .models import Post, RegistrationSettings
 from django.core.validators import URLValidator
 from martor.fields import MartorFormField
 
@@ -68,3 +68,9 @@ class CreateRegisterForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ['username', 'password']
+
+
+class RegistrationSettingsForm(forms.ModelForm):
+    class Meta:
+        model = RegistrationSettings
+        fields = ['are_new_users_active']

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.contrib.auth.models import User
 from .models import Post
 from django.core.validators import URLValidator
 from martor.fields import MartorFormField

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.auth.models import User
-from .models import Post, RegistrationSettings
+from .models import Post
 from django.core.validators import URLValidator
 from martor.fields import MartorFormField
 
@@ -68,9 +68,3 @@ class CreateRegisterForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ['username', 'password']
-
-
-class RegistrationSettingsForm(forms.ModelForm):
-    class Meta:
-        model = RegistrationSettings
-        fields = ['are_new_users_active']

--- a/quickcomm/models.py
+++ b/quickcomm/models.py
@@ -14,6 +14,7 @@ from django.core.validators import URLValidator
 # We used UUIDs for pkeys to be more secure.
 # TODO what are the constraints on fields being null?
 
+
 class Author(models.Model):
     """An author is a person associated with a user account via a one-to-one
     relationship."""
@@ -29,7 +30,8 @@ class Author(models.Model):
     host = models.URLField(validators=[URLValidator])
     display_name = models.CharField(max_length=100)
     github = models.URLField(blank=True, null=True, validators=[URLValidator])
-    profile_image = models.URLField(blank=True, null=True, validators=[URLValidator])
+    profile_image = models.URLField(
+        blank=True, null=True, validators=[URLValidator])
 
     # TODO determine if admins are authors
     is_admin = models.BooleanField(default=False)
@@ -42,16 +44,18 @@ class Author(models.Model):
         """Returns true if this author (self) is followed by the given author."""
         return Follow.objects.filter(follower=author, following=self).exists()
 
-
     def __str__(self):
         return f"{self.display_name} ({self.user.username})"
+
 
 class Follow(models.Model):
     """A follow is is a many-to-many relationship between authors representing a
     follow."""
 
-    follower = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='follower')
-    following = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='following')
+    follower = models.ForeignKey(
+        Author, on_delete=models.CASCADE, related_name='follower')
+    following = models.ForeignKey(
+        Author, on_delete=models.CASCADE, related_name='following')
 
     def is_bidirectional(self):
         """Returns true if the follow is bidirectional."""
@@ -59,6 +63,7 @@ class Follow(models.Model):
 
     def __str__(self):
         return f"{self.follower.__str__()} follows {self.following.__str__()}"
+
 
 class Post(models.Model):
     """A post is a post made by an author."""
@@ -85,11 +90,13 @@ class Post(models.Model):
     author = models.ForeignKey(Author, on_delete=models.CASCADE)
     categories = models.CharField(max_length=1000)
     published = models.DateTimeField(auto_now_add=True)
-    visibility = models.CharField(max_length=50, choices=PostVisibility.choices)
+    visibility = models.CharField(
+        max_length=50, choices=PostVisibility.choices)
     unlisted = models.BooleanField(default=False)
 
     def __str__(self):
         return f"{self.title} by {self.author.__str__()}"
+
 
 class Comment(models.Model):
     """A comment is a comment made by an author on a post."""
@@ -105,6 +112,7 @@ class Comment(models.Model):
     content_type = models.CharField(max_length=50, choices=CommentType.choices)
     published = models.DateTimeField(auto_now_add=True)
 
+
 class Inbox(models.Model):
     """The inbox is a relationship between an author and a post."""
 
@@ -113,6 +121,7 @@ class Inbox(models.Model):
 
     def __str__(self):
         return f"{self.author.__str__()}'s inbox contains {self.post.__str__()}"
+
 
 class Like(models.Model):
     """A like is a relationship between an author and a post."""
@@ -123,3 +132,9 @@ class Like(models.Model):
     def __str__(self):
         return f"{self.author.__str__()} likes {self.post.__str__()}"
 
+
+class RegistrationSettings(models.Model):
+    are_new_users_active = models.BooleanField(default=True)
+
+    def __str__(self):
+        return f"{self.are_new_users_active.__str__()}"

--- a/quickcomm/models.py
+++ b/quickcomm/models.py
@@ -139,6 +139,8 @@ class Like(models.Model):
 
 
 class RegistrationSettings(models.Model):
+    """A flag for admin users to determine if new users are active or not by default.
+    Should only have 1 value in database"""
     are_new_users_active = models.BooleanField(default=True)
 
     def __str__(self):

--- a/quickcomm/models.py
+++ b/quickcomm/models.py
@@ -44,6 +44,11 @@ class Author(models.Model):
         """Returns true if this author (self) is followed by the given author."""
         return Follow.objects.filter(follower=author, following=self).exists()
 
+    def is_bidirectional(self, author):
+        """Returns true if this author (self) follows and is followed by the
+        given author. In other words, a true friend."""
+        return self.follows(author) and self.following(author)
+
     def __str__(self):
         return f"{self.display_name} ({self.user.username})"
 

--- a/quickcomm/templates/quickcomm/register.html
+++ b/quickcomm/templates/quickcomm/register.html
@@ -2,11 +2,11 @@
 {% bootstrap_css %}
 {% block content %}
     <div class="Container">
-        <h1>Login</h1>
+        <h1>Register</h1>
         <form method="post">
             {% csrf_token %}
             {% bootstrap_form form %}
-            {% bootstrap_button button_type="submit" content="Login" %}
+            {% bootstrap_button button_type="submit" content="Sign Up" %}
         </form>
     </div>
 {% endblock %}

--- a/quickcomm/tests/test_views.py
+++ b/quickcomm/tests/test_views.py
@@ -17,7 +17,7 @@ class LoginViewTest(TestCase):
             'password': 'pass',
         })
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(
             response.wsgi_request.user.is_authenticated, response.content)
 
@@ -36,7 +36,8 @@ class RegisterViewTest(TestCase):
     def test_register(self):
         response = self.client.post('/register/', {
             'username': 'user1',
-            'password': 'pass1',
+            'password1': 'pass1',
+            'password2': 'pass1',
         })
 
         self.assertEqual(response.status_code, 302)
@@ -46,7 +47,8 @@ class RegisterViewTest(TestCase):
     def test_duplicate_register(self):
         response = self.client.post('/register/', {
             'username': 'user',
-            'password': 'pass',
+            'password1': 'pass',
+            'password2': 'pass',
         })
         self.assertEqual(response.status_code, 200)
         self.assertFalse(
@@ -58,7 +60,8 @@ class RegisterViewTest(TestCase):
 
         response = self.client.post('/register/', {
             'username': 'user2',
-            'password': 'pass2',
+            'password1': 'pass2',
+            'password2': 'pass2',
         })
         self.assertEqual(response.status_code, 302)
         self.assertFalse(
@@ -78,7 +81,7 @@ class LogoutViewTest(TestCase):
             'password': 'pass',
         })
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
         self.assertTrue(
             response.wsgi_request.user.is_authenticated)
 

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login as auth_login, logout as auth_logout
 from django.contrib.auth.models import User
 from quickcomm.forms import CreateMarkdownForm, CreatePlainTextForm, CreateLoginForm, CreateRegisterForm
-from quickcomm.models import Author, Post
+from quickcomm.models import Author, Post, RegistrationSettings
 
 # Create your views here.
 
@@ -80,7 +80,13 @@ def register(request):
                     username=username, password=password)
                 author = Author(user=user)
                 author.save()
-                auth_login(request, user)
+                # either log the user in or set their account to inactve
+                admin_approved = RegistrationSettings.objects.first().are_new_users_active
+                if admin_approved:
+                    auth_login(request, user)
+                else:
+                    user.is_active = False
+                    user.save()
                 return redirect('/')
             else:
                 form = CreateRegisterForm()

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login as auth_login, logout as auth_logout
 from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
-from quickcomm.forms import CreateMarkdownForm, CreatePlainTextForm, CreateLoginForm, CreateRegisterForm
+from quickcomm.forms import CreateMarkdownForm, CreatePlainTextForm, CreateLoginForm
 from quickcomm.models import Author, Post, RegistrationSettings
 
 # Create your views here.

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -74,7 +74,7 @@ def register(request):
         form = UserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
-            author = Author(user=user)
+            author = Author(user=user, host='http://127.0.0.1:8000', display_name=user, github='https://github.com/', profile_image='https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png')
             author.save()
             # either log the user in or set their account to inactve
             admin_approved = RegistrationSettings.objects.first().are_new_users_active

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -2,7 +2,6 @@ from django.shortcuts import render, redirect
 from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login as auth_login, logout as auth_logout
-from django.contrib.auth.models import User
 from django.contrib.auth.forms import UserCreationForm
 from quickcomm.forms import CreateMarkdownForm, CreatePlainTextForm, CreateLoginForm
 from quickcomm.models import Author, Post, RegistrationSettings
@@ -85,8 +84,6 @@ def register(request):
                 user.is_active = False
                 user.save()
             return redirect('/')
-        else:
-            form = UserCreationForm()
     else:
         form = UserCreationForm()
     context = {


### PR DESCRIPTION
Creates a new field in the admin page where an admin can make it so all new users are inactive by default.

The implementation is a bit janky, as we now have a new model for RegistrationSettings which just contains values that are a boolean. It requires one entry to exist and will always look at the first one.

To test this, log in as a superuser and go to the admin panel and create an entry in RegistrationSettings that is set to false.

Then try to create a new user. When you submit the form, it should take you to the home page where you are logged out. Try to login with that new user and it should fail.

Head back to the admin panel and you should be able to find the user you created but the 'is_active' flag should be false. Set it to true and then try to login with that user you just created. It should work.

Head back to the admin panel and change the registration settings to true.

Now try to register as a new user again. Since you set the flag to true, it should log you in as the new user when you are done.

There are view tests for this PR but there are not any model tests.

If anyone has a better suggestion on how to implement this I'm open to hear it, but this is safe and will get the job done until we find a better solution.

This PR also adds on the built-in django auth form for registration and will properly redirect a user to the home page after logging in or signing up.