### PR TITLE
Ignore authors where github does not work

### DIFF
--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -38,6 +38,9 @@ def index(request):
     following.append(author)
     for follow in following:
         github = get_github_stream(follow.github)
+        if 'message' in github:
+            if github['message'] == 'Not Found':
+                continue
         github = [dict(item, **{
             'format': 'github',
             'localAuthor': Author.objects.all()[0],


### PR DESCRIPTION
Just a quick fix that fixes the issue of new users getting a broken page.

Can test by registering a new user and seeing the home page, then adding your github username to the 'github' field in the profile and then seeing your feed.

You can also create a new user and have them follow the original user. There should be no issues with the main feed loading for either person regardless of if they have a github or not.