### PR TITLE
Change GitHub to be URL

### DIFF
--- a/quickcomm/external_requests.py
+++ b/quickcomm/external_requests.py
@@ -5,9 +5,11 @@ import requests_cache
 # This caches the requests for 5 minutes, so we don't blow up the GitHub API
 session = requests_cache.CachedSession('github_cache', expire_after=300)
 
-def get_github_stream(username):
+def get_github_stream(github):
     """Get the stream of a user from GitHub"""
-
+    # given the url, take the last section as the username
+    
+    username = github.split('/')[-1]
     url = f'https://api.github.com/users/{username}/events/public'
     response = session.get(url)
     return response.json()

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -160,7 +160,7 @@ class CreateLoginForm(forms.Form):
         
 class EditProfileForm(forms.Form):
     display_name = forms.CharField(max_length=100, required=False)
-    github = forms.CharField(required=False)
+    github = forms.URLField(required=False)
     profile_image = forms.URLField(validators=[URLValidator], required=False)
         
     def save(self, author):

--- a/quickcomm/models.py
+++ b/quickcomm/models.py
@@ -33,7 +33,7 @@ class Author(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     host = models.URLField(validators=[URLValidator])
     display_name = models.CharField(max_length=100)
-    github = models.CharField(max_length=50, blank=True, null=True)
+    github = models.URLField(max_length=50, blank=True, null=True)
     profile_image = models.URLField(blank=True, null=True, validators=[URLValidator])
 
     # TODO determine if admins are authors

--- a/quickcomm/serializers.py
+++ b/quickcomm/serializers.py
@@ -15,7 +15,7 @@ class AuthorSerializer(serializers.ModelSerializer):
     profileImage = serializers.URLField(source='profile_image', required=False)
     host = serializers.URLField(required=False)
     displayName = serializers.CharField(source='display_name', required=False)
-    github = serializers.CharField(required=False)
+    github = serializers.URLField(required=False)
 
     # TODO keep GitHub as a URLField
 
@@ -27,7 +27,7 @@ class AuthorSerializer(serializers.ModelSerializer):
             "url": "http://localhost:8000/api/authors/de574df8-6543-4566-b1cb-8cb74c70e8be/",
             "host": "http://localhost:8000/",
             "displayName":"Greg Johnson",
-            "github": "gjohnson",
+            "github": "https://github.com/gjohnson",
             "profileImage": "https://i.imgur.com/k7XVwpB.jpeg"
         }
         return examples

--- a/quickcomm/tests/test_api_authors.py
+++ b/quickcomm/tests/test_api_authors.py
@@ -14,7 +14,7 @@ class PublicAuthorsTests(TestCase):
         # setup fake data
         self.user = User.objects.create_user(username='rajan', password='badpassword')
         self.user.save()
-        self.author = Author.objects.create(user=self.user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='rajanmaghera', profile_image='https://url.com')
+        self.author = Author.objects.create(user=self.user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='https://github.com/rajanmaghera', profile_image='https://url.com')
         self.author.save()
 
 

--- a/quickcomm/tests/test_models.py
+++ b/quickcomm/tests/test_models.py
@@ -15,7 +15,7 @@ class AuthorModelTest(TestCase):
         user.save()
 
         # Create an author
-        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='rajanmaghera', profile_image='https://avatars.githubusercontent.com/u/16507599?v=4')
+        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='https://github.com/rajanmaghera', profile_image='https://avatars.githubusercontent.com/u/16507599?v=4')
         author.full_clean()
 
 
@@ -51,7 +51,7 @@ class AuthorModelTest(TestCase):
         author = Author.objects.all()[0]
         self.assertEquals(author.host, 'http://127.0.0.1:8000')
         self.assertEquals(author.display_name, 'My Real Cool Name')
-        self.assertEquals(author.github, 'rajanmaghera')
+        self.assertEquals(author.github, 'https://github.com/rajanmaghera')
         self.assertEquals(author.profile_image, 'https://avatars.githubusercontent.com/u/16507599?v=4')
 
     def test_author_update(self):
@@ -86,6 +86,7 @@ class AuthorModelTest(TestCase):
         self.assertRaises(ValidationError, author.full_clean)
 
         author.host = 'https://realurl.com/along'
+        author.github = 'https://github.com/realURL'
         author.full_clean()
 
 
@@ -100,7 +101,7 @@ class PostModelTest(TestCase):
         user.save()
 
         # Create an author
-        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='rajanmaghera', profile_image='https://avatars.githubusercontent.com/u/16507599?v=4')
+        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='My Real Cool Name', github='https://github.com/rajanmaghera', profile_image='https://avatars.githubusercontent.com/u/16507599?v=4')
         author.full_clean()
 
         # Create a post

--- a/quickcomm/tests/test_views.py
+++ b/quickcomm/tests/test_views.py
@@ -136,10 +136,10 @@ class LikeCommentTestCase(TestCase):
             password='pass2'
         )
 
-        self.author1 = Author.objects.create(user=self.user1, host='http://127.0.0.1:8000', display_name='user1', github='https://github.com/', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
+        self.author1 = Author.objects.create(user=self.user1, host='http://127.0.0.1:8000', display_name='user1', github='https://github.com/test', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
         self.author1.save()
 
-        self.author2 = Author.objects.create(user=self.user2, host='http://127.0.0.1:8000', display_name='user2', github='https://github.com/', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
+        self.author2 = Author.objects.create(user=self.user2, host='http://127.0.0.1:8000', display_name='user2', github='https://github.com/test', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
         self.author2.save()
 
         self.post = Post.objects.create(author=self.author1, title='My Post', source='http://someurl.ca', origin='http://someotherurl.ca', description='My Post Description', content_type='text/plain', content='My Post Content', visibility='PUBLIC', unlisted=False, categories='["test"]')
@@ -173,7 +173,7 @@ class EditProfileViewTest(TestCase):
         
         user.save()
         
-        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='First Name', github='https://github.com/', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
+        author = Author.objects.create(user=user, host='http://127.0.0.1:8000', display_name='First Name', github='https://github.com/test', profile_image='https://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg')
         author.full_clean()
         author.save()
         
@@ -183,7 +183,7 @@ class EditProfileViewTest(TestCase):
         author = Author.objects.all()[0]
         response = c.post('/authors/'+str(author.id)+"/", {
             'display_name': 'Second Name',
-            'github': 'http://github.com/please',
+            'github': 'https://github.com/test',
             'profile_image': 'http://www.history.com/.image/c_fit%2Ccs_srgb%2Cfl_progressive%2Cq_auto:good%2Cw_620/MTU3ODc5MDg2NDM2NjU2NDU3/reagan_flags.jpg'
         })
         self.assertEqual(response.status_code, 200)
@@ -212,7 +212,7 @@ class EditProfileViewTest(TestCase):
         c.login(username='user', password='pass')
 
         response = c.post('/authors/'+str(author.id)+"/", {
-            'github': 'http://github.com/please',
+            'github': 'https://github.com/newTest',
         })
 
         self.assertEqual(response.status_code, 200)

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -38,16 +38,20 @@ def index(request):
     following = [ follow.following for follow in Follow.objects.filter(follower=author) ]
     following.append(author)
     for follow in following:
-        github = get_github_stream(follow.github)
-        if 'message' in github:
-            if github['message'] == 'Not Found':
-                continue
-        github = [dict(item, **{
-            'format': 'github',
-            'localAuthor': Author.objects.all()[0],
-            'added': parser.parse(item["created_at"])
-                                }) for item in github]
-        inbox.extend(github)
+        try:
+            github = get_github_stream(follow.github)
+            if 'message' in github:
+                if github['message'] == 'Not Found':
+                    continue
+            github = [dict(item, **{
+                'format': 'github',
+                'localAuthor': Author.objects.all()[0],
+                'added': parser.parse(item["created_at"])
+                                    }) for item in github]
+            inbox.extend(github)
+        except:
+            continue
+
 
     def get_date(item):
         """Get the date of the item, regardless of whether it's a dict or an object."""


### PR DESCRIPTION
Allows us to save urls in profile data and properly load github events into the stream. It is not perfect since it does not check to see if the URL is for github, it just takes the last part of the url and uses it as a username.

This could be refactored to make github username a property in the model, but that change can be done after Rajan's PR is merged in.

Updated associated tests and made the logic to populate inbox stream with github events more stable.

Test the PR by trying to update the github URL with your github and see events appear in inbox. Try to change github to just your username and it should fail.
