### PR TITLE
Jordan friend post

### DIFF
--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -43,7 +43,6 @@ class CreateMarkdownForm(forms.Form):
     categories = forms.CharField(max_length=1000)
     visibility = forms.ChoiceField(choices=Post.PostVisibility.choices)
     unlisted = forms.BooleanField(required=False)
-    friends_only=forms.BooleanField(required=False)
 
     def save(self, author):
         post = Post(
@@ -70,7 +69,6 @@ class CreateImageForm(forms.Form):
     categories = forms.CharField(max_length=1000)
     visibility = forms.ChoiceField(choices=Post.PostVisibility.choices)
     unlisted = forms.BooleanField(required=False)
-    friends_only=forms.BooleanField(required=False)
 
     def get_content_type(self):
         ct_raw = self.cleaned_data['content'].content_type

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -12,8 +12,6 @@ class CreatePlainTextForm(forms.Form):
     """A form for creating a plain text post."""
 
     title = forms.CharField(max_length=100)
-    # source = forms.URLField(validators=[URLValidator])
-    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = forms.CharField(widget=forms.Textarea())
     categories = forms.CharField(max_length=1000)
@@ -40,8 +38,6 @@ class CreateMarkdownForm(forms.Form):
     """A form for creating a markdown post."""
 
     title = forms.CharField(max_length=100)
-    # source = forms.URLField(validators=[URLValidator])
-    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = MartorFormField()
     categories = forms.CharField(max_length=1000)
@@ -69,8 +65,6 @@ class CreateImageForm(forms.Form):
     """A form for creating an image post."""
 
     title = forms.CharField(max_length=100)
-    # source = forms.URLField(validators=[URLValidator])
-    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = forms.ImageField(validators=[validate_image_upload_format])
     categories = forms.CharField(max_length=1000)

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -47,6 +47,7 @@ class CreateMarkdownForm(forms.Form):
     categories = forms.CharField(max_length=1000)
     visibility = forms.ChoiceField(choices=Post.PostVisibility.choices)
     unlisted = forms.BooleanField(required=False)
+    friends_only=forms.BooleanField(required=False)
 
     def save(self, author):
         post = Post(
@@ -75,6 +76,7 @@ class CreateImageForm(forms.Form):
     categories = forms.CharField(max_length=1000)
     visibility = forms.ChoiceField(choices=Post.PostVisibility.choices)
     unlisted = forms.BooleanField(required=False)
+    friends_only=forms.BooleanField(required=False)
 
     def get_content_type(self):
         ct_raw = self.cleaned_data['content'].content_type

--- a/quickcomm/forms.py
+++ b/quickcomm/forms.py
@@ -12,8 +12,8 @@ class CreatePlainTextForm(forms.Form):
     """A form for creating a plain text post."""
 
     title = forms.CharField(max_length=100)
-    source = forms.URLField(validators=[URLValidator])
-    origin = forms.URLField(validators=[URLValidator])
+    # source = forms.URLField(validators=[URLValidator])
+    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = forms.CharField(widget=forms.Textarea())
     categories = forms.CharField(max_length=1000)
@@ -23,8 +23,8 @@ class CreatePlainTextForm(forms.Form):
     def save(self, author):
         post = Post(
             title=self.cleaned_data['title'],
-            source=self.cleaned_data['source'],
-            origin=self.cleaned_data['origin'],
+            source='http://localhost:8000',
+            origin='http://localhost:8000',
             description=self.cleaned_data['description'],
             content_type="text/plain",
             content=self.cleaned_data['content'],
@@ -40,8 +40,8 @@ class CreateMarkdownForm(forms.Form):
     """A form for creating a markdown post."""
 
     title = forms.CharField(max_length=100)
-    source = forms.URLField(validators=[URLValidator])
-    origin = forms.URLField(validators=[URLValidator])
+    # source = forms.URLField(validators=[URLValidator])
+    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = MartorFormField()
     categories = forms.CharField(max_length=1000)
@@ -51,8 +51,8 @@ class CreateMarkdownForm(forms.Form):
     def save(self, author):
         post = Post(
             title=self.cleaned_data['title'],
-            source=self.cleaned_data['source'],
-            origin=self.cleaned_data['origin'],
+            source='http://localhost:8000',
+            origin='http://localhost:8000',
             description=self.cleaned_data['description'],
             content_type="text/markdown",
             content=self.cleaned_data['content'],
@@ -68,8 +68,8 @@ class CreateImageForm(forms.Form):
     """A form for creating an image post."""
 
     title = forms.CharField(max_length=100)
-    source = forms.URLField(validators=[URLValidator])
-    origin = forms.URLField(validators=[URLValidator])
+    # source = forms.URLField(validators=[URLValidator])
+    # origin = forms.URLField(validators=[URLValidator])
     description = forms.CharField(max_length=1000)
     content = forms.ImageField(validators=[validate_image_upload_format])
     categories = forms.CharField(max_length=1000)
@@ -88,8 +88,8 @@ class CreateImageForm(forms.Form):
 
         post = Post(
             title=self.cleaned_data['title'],
-            source=self.cleaned_data['source'],
-            origin=self.cleaned_data['origin'],
+            source='http://localhost:8000',
+            origin='http://localhost:8000',
             description=self.cleaned_data['description'],
             content_type=self.get_content_type(),
             content="",

--- a/quickcomm/models.py
+++ b/quickcomm/models.py
@@ -421,22 +421,24 @@ class Post(models.Model):
         if self.content_type == Post.PostType.PNG or self.content_type == Post.PostType.JPG:
             if not ImageFile.objects.filter(post=self).exists():
                 return saved
+            
+        else:
+            # When we save a post, we also need to create an inbox post for each
+            # follower of the author.
 
-        # When we save a post, we also need to create an inbox post for each
-        # follower of the author.
+            followers = Follow.objects.filter(following=self.author)
 
-        followers = Follow.objects.filter(following=self.author)
-
-        for follower in followers:
-            print(follower.follower)
-            if not Inbox.objects.filter(content_type=ContentType.objects.get_for_model(self), object_id=self.id, author=follower.follower).exists():
-                Inbox.objects.create(content_object=self, author=follower.follower, inbox_type=Inbox.InboxType.POST)
+            for follower in followers:
+                # If this is a friend post, only create the post for true friends
+                if (self.visibility != 'PUBLIC' and follower.is_bidirectional()) or self.visibility == 'PUBLIC':
+                    if not Inbox.objects.filter(content_type=ContentType.objects.get_for_model(self), object_id=self.id, author=follower.follower).exists():
+                        Inbox.objects.create(content_object=self, author=follower.follower, inbox_type=Inbox.InboxType.POST)
 
 
-        # We also include the author as a follower of themselves to simplify
-        # the inbox logic.
-        if not Inbox.objects.filter(content_type=ContentType.objects.get_for_model(self), object_id=self.id, author=self.author).exists():
-            Inbox.objects.create(content_object=self, author=self.author, inbox_type=Inbox.InboxType.POST)
+            # We also include the author as a follower of themselves to simplify
+            # the inbox logic.
+            if not Inbox.objects.filter(content_type=ContentType.objects.get_for_model(self), object_id=self.id, author=self.author).exists():
+                Inbox.objects.create(content_object=self, author=self.author, inbox_type=Inbox.InboxType.POST)
 
         return saved
 

--- a/quickcomm/templates/quickcomm/notallowed.html
+++ b/quickcomm/templates/quickcomm/notallowed.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Author Error</title>
+</head>
+<body>
+
+    <h1>403: Forbidden</h1>
+    <p>Sorry, it looks like you aren't allowed to access this page.</p>
+</body>
+</html>

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -408,7 +408,7 @@ def view_requests(request,author_id):
         'author':author
     })
 
-@login_required
+@author_required
 def send_follow_request(request,author_id):
     from_user=get_current_author(request)
     to_user=get_object_or_404(Author,pk=author_id)
@@ -426,7 +426,7 @@ def send_follow_request(request,author_id):
         messages.error(request, "Could not process request.")
         return redirect("view_profile", author_id=author_id)
     
-@login_required    
+@author_required    
 def accept_request(request,author_id):
     target=get_current_author(request)
     follower=get_object_or_404(Author,pk=author_id)
@@ -438,7 +438,7 @@ def accept_request(request,author_id):
     messages.success(request, "Request from "+follower.display_name+" accepted!")
     return redirect("view_requests", author_id=author_id)
 
-@login_required
+@author_required
 def unfriend(request,author_id):
     current_author=get_current_author(request)
     following=get_object_or_404(Author,pk=author_id)
@@ -448,20 +448,21 @@ def unfriend(request,author_id):
     messages.success(request, "Unfollowed "+following.display_name)
     return redirect("view_profile", author_id=author_id)
 
-@login_required
+@author_required
 def decline_request(request,author_id):
     from_user=get_current_author(request)
     to_user=get_object_or_404(Author,pk=author_id)
     pass
-                    
+            
+@author_required        
 def view_author_posts(request, author_id):
     author = get_object_or_404(Author, pk=author_id)
-    current_author = get_current_author(request)
+    current_author = request.author
 
     if author.is_remote and not author.is_temporary:
         sync_posts(author)
 
-    posts = Post.objects.filter(author=author)
+    posts = Post.objects.filter(author=author, visibility=Post.PostVisibility.PUBLIC)
 
     size = request.GET.get('size', '10')
     paginator = Paginator(posts, size)

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -435,7 +435,7 @@ def decline_request(request,author_id):
                     
 def view_author_posts(request, author_id):
     author = get_object_or_404(Author, pk=author_id)
-    current_author = request.author
+    current_author = get_current_author(request)
 
     if author.is_remote and not author.is_temporary:
         sync_posts(author)

--- a/quickcomm/views.py
+++ b/quickcomm/views.py
@@ -272,7 +272,7 @@ def register(request):
         form = UserCreationForm(request.POST)
         if form.is_valid():
             user = form.save()
-            author = Author(user=user, host='http://127.0.0.1:8000', display_name=user, github='https://github.com/', profile_image='https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png')
+            author = Author(user=user, display_name=user, github='https://github.com/', profile_image='https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png')
             author.save()
             # either log the user in or set their account to inactve
             admin_approved = RegistrationSettings.objects.first().are_new_users_active


### PR DESCRIPTION
This PR enforces friend posts, meaning you can not access a friend post on the server unless you are a friend of the person who posted it.

Similar logic will be extended for private posts.

There are not any tests created for this new functionality yet. I plan to add them next (when I implement the logic for private posts).

The best way to test is to create 3 users and make 2 of them friends. Create a friends-only post and a public post. Check to make sure all 3 users can view the proper posts.